### PR TITLE
fix: fixed string enums for python 3.11

### DIFF
--- a/custom_components/tattelecom_intercom/enum.py
+++ b/custom_components/tattelecom_intercom/enum.py
@@ -18,21 +18,21 @@ class DeviceClass(StrEnum):
     CALL_STATE = f"{DOMAIN}__call_state"
 
 
-class Method(str, Enum):
+class Method(StrEnum):
     """Method enum"""
 
     GET = "GET"
     POST = "POST"
 
 
-class ApiVersion(str, Enum):
+class ApiVersion(StrEnum):
     """Api version enum"""
 
     V1 = "v1"
     V2 = "v2"
 
 
-class CallState(str, Enum):
+class CallState(StrEnum):
     """Call state enum"""
 
     DIALING = "dialing"
@@ -41,7 +41,7 @@ class CallState(str, Enum):
     ENDED = "ended"
 
 
-class VoipState(str, Enum):
+class VoipState(StrEnum):
     """Voip state enum"""
 
     INACTIVE = "inactive"
@@ -64,7 +64,7 @@ class MessageType(IntEnum):
     RESPONSE = 0
 
 
-class RtpProtocol(str, Enum):
+class RtpProtocol(StrEnum):
     """Rtp protocol"""
 
     UDP = "udp"
@@ -72,7 +72,7 @@ class RtpProtocol(str, Enum):
     SAVP = "RTP/SAVP"
 
 
-class SendMode(str, Enum):
+class SendMode(StrEnum):
     """Send mode"""
 
     RECV_ONLY = "recvonly"
@@ -202,7 +202,7 @@ class RtpPayloadType(Enum):
     UNKNOWN = "UNKNOWN", 0, 0, "UNKNOWN CODEC"
 
 
-class TransmitType(str, Enum):
+class TransmitType(StrEnum):
     """Rtp transmit type"""
 
     RECVONLY = "recvonly"


### PR DESCRIPTION
В python 3.11 изменилось поведение классов наследующихся от str и Enum:
```
# Python 3.10
CLIENT_URL.format(api_version=ApiVersion.V1, path='')
# https://domofon.tattelecom.ru/v1/

# Python 3.11
CLIENT_URL.format(api_version=ApiVersion.V1, path='')
# https://domofon.tattelecom.ru/ApiVersion.V1/
```

Должно пофиксить #5 (в 2023.6 обновили python до 3.11)